### PR TITLE
Update platform.cpp to fix compilation on FreeBSD

### DIFF
--- a/mdflib/src/platform.cpp
+++ b/mdflib/src/platform.cpp
@@ -31,7 +31,7 @@ int strnicmp(const char *__s1, const char *__s2, size_t __n) {
 void strerror(int __errnum, char *__buf, size_t __buflen) {
 #if (_WIN32)
   strerror_s(__buf, __buflen, __errnum);
-#elif (__APPLE__)
+#elif (__APPLE__ || __FreeBSD__)
   int err = strerror_r(__errnum, __buf, __buflen);
   if (err == 0)
   {


### PR DESCRIPTION
When trying to compile the CMake target "mdf" on FreeBSD the compilation fails because strerror_r gets called using the wrong syntax. In FreeBSD strerror_r uses the same syntax as in macOS.